### PR TITLE
Removed branch only master from CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,6 @@ jobs:
       - image: circleci/node:latest-browsers
 
     working_directory: ~/beta
-
-    branches:
-      only:
-        - master
     
     steps:
       - checkout


### PR DESCRIPTION
# Description

I took out the code in the CI config file that I believe was causing CI to not test code that didn't come from the master branch.

# Reviewing

One of our internal CI experts (presumably Andrew) should check and make sure that these changes don't totally break our CI environment.

# Tests
I affirm that I've tested my code on:
- [ ] Desktop
- [ ] Tablet
- [ ] Mobile
(Chrome tools counts)

I haven't done any of the above tests, but after scanning the circle CI docs I believe the changes I've made are valid.
