### PR TITLE
Add AttendAndSponsorBoxes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { Flex, Box } from "grid-styled";
 import {
   AttendBox,
   SponsorBox,
@@ -12,55 +13,64 @@ import HeroText from "./components/HeroText";
 class App extends Component {
   render() {
     return (
-      <div className="App">
-        <div className="Flair">
-          <div className="headerbar">
-            <HeroText
-              title="Boston"
-              titleBold="Hacks"
-              date="November 10th - November 11th"
-              location="Boston University"
-            />
+      <div>
+        <div className="App">
+          <div className="Flair">
+            <div className="headerbar">
+              <HeroText
+                title="Boston"
+                titleBold="Hacks"
+                date="November 10th - November 11th"
+                location="Boston University"
+              />
+            </div>
           </div>
-        </div>
-        <div>
-          <AttendBox />
-          <SponsorBox />
-        </div>
-        <div>
-          <h2>
-            <Header
-              contentProp="Event Schedule"
-              colorProp="#EF833F"
-              backgroundProp="#FFFFFF"
-            />
-          </h2>
-          <EventSchedule />
-        </div>
+          <Flex className="attendSponsorFlex">
+            <Box width={[0, 1 / 4, 1 / 4]} />
+            <Box width={[1, 1 / 4, 1 / 5]}>
+              <AttendBox />
+            </Box>
+            <Box width={[0, 0, 1 / 10]} />
+            <Box width={[1, 1 / 4, 1 / 5]}>
+              <SponsorBox />
+            </Box>
+            <Box width={[0, 1 / 4, 1 / 4]} />
+          </Flex>
+          <div>
+            <h2>
+              <Header
+                contentProp="Event Schedule"
+                colorProp="#EF833F"
+                backgroundProp="#FFFFFF"
+              />
+            </h2>
+            <EventSchedule />
+          </div>
 
-        <div>
-          <TracksAndWorkshops />
-        </div>
+          <div>
+            <TracksAndWorkshops />
+          </div>
 
-        <div>
-          <h2>
-            <Header
-              contentProp="Frequently Asked Questions"
-              colorProp="#3CBFCE"
-              backgroundProp="#FFFFFF"
-            />
-          </h2>
-          <FAQSection />
-        </div>
+          <div>
+            <h2>
+              <Header
+                contentProp="Frequently Asked Questions"
+                colorProp="#3CBFCE"
+                backgroundProp="#FFFFFF"
+              />
+            </h2>
+            <FAQSection />
+          </div>
 
-        <div>
-          <h2>
-            <Header
-              contentProp="The Footer"
-              colorProp="#FFFFFF"
-              backgroundProp="#3dbecd"
-            />
-          </h2>
+          <div>
+            <h2>
+              <Header
+                contentProp="The Footer"
+                colorProp="#FFFFFF"
+                backgroundProp="#3dbecd"
+              />
+            </h2>
+          </div>
         </div>
       </div>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,7 @@
 import React, { Component } from "react";
-import { Flex, Box } from "grid-styled";
+
 import {
-  AttendBox,
-  SponsorBox,
+  AttendAndSponsorBoxes,
   EventSchedule,
   FAQSection,
   TracksAndWorkshops
@@ -25,17 +24,8 @@ class App extends Component {
               />
             </div>
           </div>
-          <Flex className="attendSponsorFlex">
-            <Box width={[0, 1 / 4, 1 / 4]} />
-            <Box width={[1, 1 / 4, 1 / 5]}>
-              <AttendBox />
-            </Box>
-            <Box width={[0, 0, 1 / 10]} />
-            <Box width={[1, 1 / 4, 1 / 5]}>
-              <SponsorBox />
-            </Box>
-            <Box width={[0, 1 / 4, 1 / 4]} />
-          </Flex>
+
+          <AttendAndSponsorBoxes />
 
           <EventSchedule />
 

--- a/src/App.js
+++ b/src/App.js
@@ -36,41 +36,18 @@ class App extends Component {
             </Box>
             <Box width={[0, 1 / 4, 1 / 4]} />
           </Flex>
-          <div>
-            <h2>
-              <Header
-                contentProp="Event Schedule"
-                colorProp="#EF833F"
-                backgroundProp="#FFFFFF"
-              />
-            </h2>
-            <EventSchedule />
-          </div>
 
-          <div>
-            <TracksAndWorkshops />
-          </div>
+          <EventSchedule />
 
-          <div>
-            <h2>
-              <Header
-                contentProp="Frequently Asked Questions"
-                colorProp="#3CBFCE"
-                backgroundProp="#FFFFFF"
-              />
-            </h2>
-            <FAQSection />
-          </div>
+          <TracksAndWorkshops />
 
-          <div>
-            <h2>
-              <Header
-                contentProp="The Footer"
-                colorProp="#FFFFFF"
-                backgroundProp="#3dbecd"
-              />
-            </h2>
-          </div>
+          <FAQSection />
+
+          <Header
+            contentProp="The Footer"
+            colorProp="#FFFFFF"
+            backgroundProp="#3dbecd"
+          />
         </div>
       </div>
     );

--- a/src/components/AttendAndSponsorBoxes/AttendAndSponsorBoxes.js
+++ b/src/components/AttendAndSponsorBoxes/AttendAndSponsorBoxes.js
@@ -3,19 +3,21 @@ import AttendBox from "../AttendBox";
 import SponsorBox from "../SponsorBox";
 import { Flex, Box } from "grid-styled";
 
+// Another pattern that is closer to the design but has small boxes:
+// 1/4 + 13/60 + 4/60 + 13/60 + 1/4
 class AttendAndSponsorBoxes extends Component {
   render() {
     return (
       <Flex className="attendSponsorFlex">
-        <Box width={[0, 1 / 4, 1 / 4]} />
-        <Box width={[1, 1 / 4, 13 / 60]}>
+        <Box width={[0, 1 / 4, 1 / 5]} />
+        <Box width={[1, 1 / 4, 5 / 20]}>
           <AttendBox />
         </Box>
-        <Box width={[0, 0, 4 / 60]} />
-        <Box width={[1, 1 / 4, 13 / 60]}>
+        <Box width={[0, 0, 1 / 10]} />
+        <Box width={[1, 1 / 4, 5 / 20]}>
           <SponsorBox />
         </Box>
-        <Box width={[0, 1 / 4, 1 / 4]} />
+        <Box width={[0, 1 / 4, 1 / 5]} />
       </Flex>
     );
   }

--- a/src/components/AttendAndSponsorBoxes/AttendAndSponsorBoxes.js
+++ b/src/components/AttendAndSponsorBoxes/AttendAndSponsorBoxes.js
@@ -9,15 +9,15 @@ class AttendAndSponsorBoxes extends Component {
   render() {
     return (
       <Flex className="attendSponsorFlex">
-        <Box width={[0, 1 / 4, 1 / 5]} />
-        <Box width={[1, 1 / 4, 5 / 20]}>
+        <Box width={[0, 1 / 11, 1 / 5]} />
+        <Box width={[1, 4 / 11, 5 / 20]}>
           <AttendBox />
         </Box>
-        <Box width={[0, 0, 1 / 10]} />
-        <Box width={[1, 1 / 4, 5 / 20]}>
+        <Box width={[0, 1 / 11, 1 / 10]} />
+        <Box width={[1, 4 / 11, 5 / 20]}>
           <SponsorBox />
         </Box>
-        <Box width={[0, 1 / 4, 1 / 5]} />
+        <Box width={[0, 1 / 11, 1 / 5]} />
       </Flex>
     );
   }

--- a/src/components/AttendAndSponsorBoxes/AttendAndSponsorBoxes.js
+++ b/src/components/AttendAndSponsorBoxes/AttendAndSponsorBoxes.js
@@ -1,0 +1,24 @@
+import React, { Component } from "react";
+import AttendBox from "../AttendBox";
+import SponsorBox from "../SponsorBox";
+import { Flex, Box } from "grid-styled";
+
+class AttendAndSponsorBoxes extends Component {
+  render() {
+    return (
+      <Flex className="attendSponsorFlex">
+        <Box width={[0, 1 / 4, 1 / 4]} />
+        <Box width={[1, 1 / 4, 13 / 60]}>
+          <AttendBox />
+        </Box>
+        <Box width={[0, 0, 4 / 60]} />
+        <Box width={[1, 1 / 4, 13 / 60]}>
+          <SponsorBox />
+        </Box>
+        <Box width={[0, 1 / 4, 1 / 4]} />
+      </Flex>
+    );
+  }
+}
+
+export default AttendAndSponsorBoxes;

--- a/src/components/AttendAndSponsorBoxes/index.js
+++ b/src/components/AttendAndSponsorBoxes/index.js
@@ -1,0 +1,2 @@
+import AttendAndSponsorBoxes from "./AttendAndSponsorBoxes";
+export default AttendAndSponsorBoxes;

--- a/src/components/AttendBox/AttendBox.js
+++ b/src/components/AttendBox/AttendBox.js
@@ -1,11 +1,16 @@
 import React, { Component, Fragment } from "react";
 import Header from "../Header";
 
+const InvalidEmailText = () => (
+  <p>Oh no! We couldn&#39;t recognize that email. Typo?</p>
+);
+
 class AttendBox extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      userEmail: ""
+      userEmail: "",
+      showInvalidEmailText: false
     };
   }
 
@@ -14,20 +19,25 @@ class AttendBox extends Component {
   };
 
   handleClick = e => {
-    // TODO: Actually add users to the mailing list
-    console.log("The email ", this.state.userEmail, " was just entered!");
     e.preventDefault();
-    this.setState({ userEmail: "" });
+
+    // Regex magic, checks whether the user entered a valid email format
+    let isValidEmail = this.state.userEmail.match(
+      /^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i
+    );
+
+    if (isValidEmail) {
+      // TODO: Add users to the mailing list here
+      this.setState({ userEmail: "", showInvalidEmailText: false });
+    } else {
+      this.setState({ showInvalidEmailText: true });
+    }
   };
 
   render() {
     return (
       <Fragment>
-        <Header
-          contentProp="Attend"
-          colorProp="#9974AD"
-          backgroundProp="#FFFFFF"
-        />
+        <Header contentProp="Attend" colorProp="#9974AD" />
         <p>
           Thanks for the interest! Leave your email address below or follow us
           on social media to get notified when there is more information and
@@ -40,6 +50,7 @@ class AttendBox extends Component {
             placeholder="Join our mailing list!"
           />
           <button onClick={this.handleClick}>Do it</button>
+          {this.state.showInvalidEmailText ? <InvalidEmailText /> : null}
         </div>
       </Fragment>
     );

--- a/src/components/AttendBox/AttendBox.js
+++ b/src/components/AttendBox/AttendBox.js
@@ -37,7 +37,7 @@ class AttendBox extends Component {
   render() {
     return (
       <Fragment>
-        <Header contentProp="Attend" colorProp="#9974AD" />
+        <Header contentProp="Attend" colorProp="#3cbfce" />
         <p>
           Thanks for the interest! Leave your email address below or follow us
           on social media to get notified when there is more information and

--- a/src/components/AttendBox/AttendBox.js
+++ b/src/components/AttendBox/AttendBox.js
@@ -2,7 +2,9 @@ import React, { Component, Fragment } from "react";
 import Header from "../Header";
 
 const InvalidEmailText = () => (
-  <p>Oh no! We couldn&#39;t recognize that email. Typo?</p>
+  <p style={{ color: "red" }}>
+    Oh no! We couldn&#39;t recognize that email. Typo?
+  </p>
 );
 
 class AttendBox extends Component {
@@ -47,9 +49,14 @@ class AttendBox extends Component {
           <input
             value={this.state.userEmail}
             onChange={this.handleChange}
-            placeholder="Join our mailing list!"
+            placeholder="hacker@anyschool.edu"
           />
-          <button onClick={this.handleClick}>Do it</button>
+          <button
+            style={{ backgroundColor: "#3cbfce" }}
+            onClick={this.handleClick}
+          >
+            Subscribe
+          </button>
           {this.state.showInvalidEmailText ? <InvalidEmailText /> : null}
         </div>
       </Fragment>

--- a/src/components/EventSchedule/EventSchedule.js
+++ b/src/components/EventSchedule/EventSchedule.js
@@ -22,15 +22,6 @@ const eventsSun = [
   { time: "2:00 PM", name: "closing ceremony" }
 ];
 
-// const EventScheduleTitle = styled.h2`
-//   color: #ef833f;
-//   font-family: "Roboto", sans-serif;
-//   font-size: 48px;
-//   font-weight: 500;
-//   position: relative;
-//   margin-left: 15%;
-// `;
-
 class EventSchedule extends Component {
   render() {
     return (

--- a/src/components/EventSchedule/EventSchedule.js
+++ b/src/components/EventSchedule/EventSchedule.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { ScheduleTable } from "../";
-import styled from "styled-components";
+import Header from "../Header";
+// import styled from "styled-components";
 import { Flex, Box } from "grid-styled";
 
 const eventsSat = [
@@ -21,20 +22,20 @@ const eventsSun = [
   { time: "2:00 PM", name: "closing ceremony" }
 ];
 
-const EventScheduleTitle = styled.h2`
-  color: #ef833f;
-  font-family: "Roboto", sans-serif;
-  font-size: 48px;
-  font-weight: 500;
-  position: relative;
-  margin-left: 15%;
-`;
+// const EventScheduleTitle = styled.h2`
+//   color: #ef833f;
+//   font-family: "Roboto", sans-serif;
+//   font-size: 48px;
+//   font-weight: 500;
+//   position: relative;
+//   margin-left: 15%;
+// `;
 
 class EventSchedule extends Component {
   render() {
     return (
       <React.Fragment>
-        <EventScheduleTitle> Event Schedule </EventScheduleTitle>
+        <Header contentProp={"Event Schedule"} colorProp="#EF833F" />
         <Flex flexWrap="wrap" justifyContent="space-between">
           <Box px={2} width={[1, 1, 1 / 2]}>
             <ScheduleTable events={eventsSat} title="Saturday" />

--- a/src/components/FAQSection/FAQSection.js
+++ b/src/components/FAQSection/FAQSection.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import Header from "../Header";
 import styled from "styled-components";
 import { Flex, Box } from "grid-styled";
 
@@ -14,11 +15,6 @@ const FAQAnswer = styled.div`
   font-family: "Roboto Slab", serif;
   font-size: 27px;
   font-weight: 300;
-`;
-
-const FAQHeader = FAQEntryTitle.extend`
-  font-size: 48px;
-  font-weight: 500;
 `;
 
 const FAQHeaderCopy = FAQAnswer.extend`
@@ -107,7 +103,10 @@ class FAQSection extends Component {
         <Flex justifyContent="space-between">
           <Box width={[0, 1 / 3]} />
           <Box p={3} width={[1, 2 / 3]}>
-            <FAQHeader> Frequently Asked Questions </FAQHeader>
+            <Header
+              contentProp={"Frequently Asked Questions"}
+              colorProp={"#3cbfce"}
+            />
             <FAQHeaderCopy>
               The event is still a ways away, so check back closer to the
               hackathon for more information.

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -2,20 +2,21 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
-const Div = styled.h2`
+const Div = styled.div`
   font-family: "Roboto", sans-serif;
   font-size: 30px;
   font-weight: 400;
+  margin: 0;
 `;
 
 export class Header extends Component {
   render() {
     return (
-      <Div style={{ background: this.props.backgroundProp }}>
-        <h3 style={{ color: this.props.colorProp }}>
+      <div style={{ background: this.props.backgroundProp }}>
+        <Div style={{ color: this.props.colorProp }}>
           {this.props.contentProp}
-        </h3>
-      </Div>
+        </Div>
+      </div>
     );
   }
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,14 +1,21 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import styled from "styled-components";
+
+const Div = styled.h2`
+  font-family: "Roboto", sans-serif;
+  font-size: 30px;
+  font-weight: 400;
+`;
 
 export class Header extends Component {
   render() {
     return (
-      <div style={{ background: this.props.backgroundProp }}>
+      <Div style={{ background: this.props.backgroundProp }}>
         <h3 style={{ color: this.props.colorProp }}>
           {this.props.contentProp}
         </h3>
-      </div>
+      </Div>
     );
   }
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,21 +1,14 @@
 import React, { Component } from "react";
-import styled from "styled-components";
 import PropTypes from "prop-types";
-
-const Div = styled.div`
-  height: 100%;
-  width: 100%;
-  font-family: .SFNSDisplay;
-`;
 
 export class Header extends Component {
   render() {
     return (
-      <Div style={{ background: this.props.backgroundProp }}>
+      <div style={{ background: this.props.backgroundProp }}>
         <h3 style={{ color: this.props.colorProp }}>
           {this.props.contentProp}
         </h3>
-      </Div>
+      </div>
     );
   }
 }
@@ -29,7 +22,7 @@ Header.propTypes = {
 Header.defaultProps = {
   contentProp: "A header should go here",
   colorProp: "#dc4b6a",
-  backgroundProp: "#3dbecd"
+  backgroundProp: "#fff"
 };
 
 export default Header;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -4,7 +4,7 @@ import styled from "styled-components";
 
 const Div = styled.div`
   font-family: "Roboto", sans-serif;
-  font-size: 30px;
+  font-size: 32px;
   font-weight: 400;
   margin: 0;
 `;

--- a/src/components/SponsorBox/SponsorBox.js
+++ b/src/components/SponsorBox/SponsorBox.js
@@ -9,7 +9,12 @@ class SponsorBox extends Component {
       <Fragment>
         <Header contentProp="Sponsor" colorProp="#fc1949" />
         <p>We would love to have you on board. Contact us here!</p>
-        <button onClick={this.handleClick}>Contact Us</button>
+        <button
+          style={{ backgroundColor: "#fc1949" }}
+          onClick={this.handleClick}
+        >
+          Contact Us
+        </button>
       </Fragment>
     );
   }

--- a/src/components/SponsorBox/SponsorBox.js
+++ b/src/components/SponsorBox/SponsorBox.js
@@ -7,7 +7,7 @@ class SponsorBox extends Component {
   render() {
     return (
       <Fragment>
-        <Header contentProp="Sponsor" colorProp="#dc4b6a" />
+        <Header contentProp="Sponsor" colorProp="#fc1949" />
         <p>We would love to have you on board. Contact us here!</p>
         <button onClick={this.handleClick}>Contact Us</button>
       </Fragment>

--- a/src/components/SponsorBox/SponsorBox.js
+++ b/src/components/SponsorBox/SponsorBox.js
@@ -7,11 +7,7 @@ class SponsorBox extends Component {
   render() {
     return (
       <Fragment>
-        <Header
-          contentProp="Sponsor"
-          colorProp="#dc4b6a"
-          backgroundProp="#FFFFFF"
-        />
+        <Header contentProp="Sponsor" colorProp="#dc4b6a" />
         <p>We would love to have you on board. Contact us here!</p>
         <button onClick={this.handleClick}>Contact Us</button>
       </Fragment>

--- a/src/components/TracksAndWorkshops/TracksAndWorkshops.js
+++ b/src/components/TracksAndWorkshops/TracksAndWorkshops.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import Header from "../Header";
 import styled from "styled-components";
 import { Grid, Row, Col } from "react-flexbox-grid";
 
@@ -33,9 +34,11 @@ export class TracksAndWorkshops extends Component {
                 <div style={centeredImg} />
               </Col>
               <Col xs={12} sm={6}>
-                <h3 style={{ color: "#B7D98B" }} align="right">
-                  Tracks and Workshops
-                </h3>
+                <Header
+                  contentProp={"Tracks and Workshops"}
+                  colorProp={"#b7d98b"}
+                  backgroundProp={"#3dbecd"}
+                />
                 <p align="right">
                   Tracks are optional specialized topics or technologies you can
                   aim your project at. We&apos;ll have sponsors, workshops, and
@@ -49,7 +52,11 @@ export class TracksAndWorkshops extends Component {
 
             <Row>
               <Col smOffset={1} sm={5}>
-                <h3 style={{ color: "#B7D98B" }}> Last year&apos;s tracks:</h3>
+                <Header
+                  contentProp={"Last year's tracks:"}
+                  colorProp={"#b7d98b"}
+                  backgroundProp={"#3dbecd"}
+                />
               </Col>
               <Col className="hidden-xs" sm={5}>
                 <div style={centeredImg} />

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -5,8 +5,7 @@ import EventSchedule from "./EventSchedule";
 import FAQSection from "./FAQSection";
 import FAQEntry from "./FAQEntry";
 import Header from "./Header";
-import AttendBox from "./AttendBox";
-import SponsorBox from "./SponsorBox";
+import AttendAndSponsorBoxes from "./AttendAndSponsorBoxes";
 import TracksAndWorkshops from "./TracksAndWorkshops";
 
 export {
@@ -17,7 +16,6 @@ export {
   FAQSection,
   FAQEntry,
   Header,
-  AttendBox,
-  SponsorBox,
+  AttendAndSponsorBoxes,
   TracksAndWorkshops
 };

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,12 @@ button {
   border-radius: 14px;
   vertical-align: center;
   cursor: pointer;
+
+  transition-duration: 0.3s;
+  outline: 0;
+}
+button:active {
+  transform: scale(0.9);
 }
 
 input {
@@ -35,6 +41,13 @@ input {
   padding: 0.7em 1.4em 0.7em 1.4em;
   margin-right: 10px;
   border-radius: 14px;
+  border-style: solid;
+  border-color: #aaa;
+  outline: 0;
+}
+
+::placeholder {
+  color: #bbb;
 }
 
 .Flair {

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,11 @@ body {
   font-family: sans-serif;
 }
 
+p {
+  font-family: "Roboto Slab", serif;
+  font-weight: 300;
+}
+
 .Flair {
   background:
       url("assets/Waves/Header_Curve1.svg") no-repeat,

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Roboto:100,700');
+@import url('https://fonts.googleapis.com/css?family=Roboto:100,300,700');
 
 html {
   height: 100%;
@@ -15,6 +15,26 @@ p {
   font-family: "Roboto Slab", serif;
   font-weight: 300;
   font-size: 18px;
+}
+
+button {
+  font-family: 'Roboto', sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  color: white;
+  padding: 0.7em 1.4em 0.7em 1.4em;
+  border-radius: 14px;
+  vertical-align: center;
+  cursor: pointer;
+}
+
+input {
+  font-family: 'Roboto', sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  padding: 0.7em 1.4em 0.7em 1.4em;
+  margin-right: 10px;
+  border-radius: 14px;
 }
 
 .Flair {

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,7 @@ body {
 p {
   font-family: "Roboto Slab", serif;
   font-weight: 300;
+  font-size: 18px;
 }
 
 .Flair {


### PR DESCRIPTION
# Description

This PR adds styling (grid-styled and css) to attend and sponsor boxes so they are aligned correctly. It also implements input validation for when a user tries to add themselves to our mailing list.

Also, behind the scenes, it makes sure that every instance of a header is changed to the Header component. We should use this component going forward to maintain style consistency.

# Reviewing

- Try adding an invalid email to the mailing list; it shouldn't let you.
- Try adding a valid email to the mailing list; it should let you.
- After loading the page make sure that attend and sponsor boxes are aligned in the middle of the page, as per the design doc.
- CSS should be finished-level quality and when you press buttons they should have a press animation.

# Tests
I affirm that I've tested my code on:
- [X] Desktop
- [X] Tablet
- [X] Mobile
(Chrome tools counts)

![bhacks wip homepage](https://user-images.githubusercontent.com/8844961/43352347-30da6bd6-91f0-11e8-9a21-88ec5405577d.png)
