### PR TITLE
Fixed typo in sponsor box

### DIFF
--- a/src/components/SponsorBox/SponsorBox.js
+++ b/src/components/SponsorBox/SponsorBox.js
@@ -39,12 +39,12 @@ class SponsorBox extends Component {
     return (
       <Fragment>
         <Title>Sponsor</Title>
+        {/* prettier-ignore */}
         <Text>
           We would love to have you on board. Contact us at&nbsp;
           <a href="mailto:contact@bostonhacks.io" style={{ color: "#f05352" }}>
             contact@bostonhacks.io
-          </a>
-          or check our sponsor document!
+          </a> or check our sponsor document!
         </Text>
         <a href={sponsor}>
           <DocButton>Learn more</DocButton>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2468,9 +2468,9 @@ eslint-plugin-node@^6.0.1:
     resolve "^1.3.3"
     semver "^5.4.1"
 
-eslint-plugin-prettier@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz#33e4e228bdb06142d03c560ce04ec23f6c767dd7"
+eslint-plugin-prettier@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz#71998c60aedfa2141f7bfcbf9d1c459bf98b4fad"
   dependencies:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
@@ -5958,9 +5958,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.13.5:
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.5.tgz#7ae2076998c8edce79d63834e9b7b09fead6bfd0"
+prettier@^1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
 
 pretty-bytes@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Prettier was enforcing a typo in sponsor box, required an ignore tag