### PR TITLE
Fix typos in FAQ section

### DIFF
--- a/src/components/FAQSection/FAQSection.js
+++ b/src/components/FAQSection/FAQSection.js
@@ -261,9 +261,9 @@ class FAQSection extends Component {
                 </FAQEntryTitle>
                 <FAQAnswer>
                   <p>
-                    Unfortunetly we’re not providing individual travel
+                    Unfortunately we’re not providing individual travel
                     reimbursements this year. However, we will be providing
-                    buses to NYC, Toronto and Montereal.
+                    buses to NYC, Toronto and Montreal.
                   </p>
                 </FAQAnswer>
               </Col>


### PR DESCRIPTION
# Description

Fixes 2 typos in the travel reimbursement FAQ.

Before:
![screen shot 2018-10-20 at 5 32 54 pm](https://user-images.githubusercontent.com/8844961/47260693-59182800-d48e-11e8-93e0-d3a6a644771e.png)

After:
![screen shot 2018-10-20 at 5 33 16 pm](https://user-images.githubusercontent.com/8844961/47260694-5ddcdc00-d48e-11e8-9474-1119d08b6f0b.png)


# Reviewing
Furrow your brow really hard like you are reviewing an important PR requiring deep programming knowledge, then just click the approve button so more people don't notice this.

# Tests
I affirm that I've tested my code on:
- [X] Desktop
- [X] Tablet
- [X] Mobile
(Chrome tools counts)
